### PR TITLE
server: prevent cache key collision

### DIFF
--- a/server/szurubooru/search/configs/post_search_config.py
+++ b/server/szurubooru/search/configs/post_search_config.py
@@ -228,6 +228,11 @@ class PostSearchConfig(BaseSearchConfig):
             )
         return query.order_by(model.Post.post_id.desc())
 
+
+    @property
+    def can_list_unsafe(self) -> bool:
+        return self.user and auth.has_privilege(self.user, "posts:list:unsafe")
+
     @property
     def id_column(self) -> SaColumn:
         return model.Post.post_id

--- a/server/szurubooru/search/executor.py
+++ b/server/szurubooru/search/executor.py
@@ -93,7 +93,10 @@ class Executor:
             if token.name == "random":
                 disable_eager_loads = True
 
-        key = (id(self.config), hash(search_query), offset, limit)
+
+        can_list_unsafe = getattr(self.config, "can_list_unsafe", False)
+
+        key = (id(self.config), hash(search_query), offset, limit, can_list_unsafe)
         if cache.has(key):
             return cache.get(key)
 


### PR DESCRIPTION
Since search queries get cached, when a search performed by a privileged user is repeated by an unprivileged user, they will receive a listing that erroneously includes unsafe posts. The same is true the other way around, a tag search that is first performed by an anonymous user will cause any hidden posts for that query to not show up for the logged in user. This is because the initial search claims the cache key.

It's easily reproducible on a single-thread wsgi server.
szurubooru's default Docker configuration uses 4 threads which don't share cache, be mindful of this if you can't reproduce the issue.